### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ release/
 *.log
 .env
 build/
+db/
+cache/

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,11 +14,12 @@ import { createMainWindow } from './services/window';
 
 const isDev = !!process.env.VITE_DEV_SERVER_URL;
 const storage = new Storage();
-const tracker = new TrackerService();
-const stats = new StatsService();
-
-// Local DB instance (replaces singleton usage)
+// Create a single DB instance and inject into all services to avoid clobbering the sql.js file
 const dbInstance = new DB();
+const tracker = new TrackerService(dbInstance);
+const stats = new StatsService(dbInstance);
+
+// Local DB instance defined above
 
 let win: BrowserWindow | null = null;
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -102,9 +102,10 @@ app.whenReady().then(() => {
       const installRoot = app.isPackaged ? path.dirname(app.getPath('exe')) : process.cwd();
       const logDir = path.join(installRoot, 'cache', 'log');
       try { if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true }); } catch {}
-      const ts = new Date();
+      const now = new Date();
       const pad = (n:number)=>String(n).padStart(2,'0');
-      const stamp = `${ts.getFullYear()}${pad(ts.getMonth()+1)}${pad(ts.getDate())}-${pad(ts.getHours())}${pad(ts.getMinutes())}${pad(ts.getSeconds())}`;
+      const half = now.getHours() < 12 ? 'AM' : 'PM';
+      const stamp = `${now.getFullYear()}${pad(now.getMonth()+1)}${pad(now.getDate())}-${half}`;
       const baseName = (cfg.logFileName || 'achievo.log').replace(/[/\\]/g,'');
       const p = cfg.logToFile ? path.join(logDir, `${stamp}_${baseName}`) : null;
       setLogFile(p);
@@ -175,9 +176,10 @@ ipcMain.handle('config:set', async (_evt, cfg: { openaiApiKey?: string; repoPath
     const installRoot = app.isPackaged ? path.dirname(app.getPath('exe')) : process.cwd();
     const logDir = path.join(installRoot, 'cache', 'log');
     try { if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true }); } catch {}
-    const ts = new Date();
+    const now = new Date();
     const pad = (n:number)=>String(n).padStart(2,'0');
-    const stamp = `${ts.getFullYear()}${pad(ts.getMonth()+1)}${pad(ts.getDate())}-${pad(ts.getHours())}${pad(ts.getMinutes())}${pad(ts.getSeconds())}`;
+    const half = now.getHours() < 12 ? 'AM' : 'PM';
+    const stamp = `${now.getFullYear()}${pad(now.getMonth()+1)}${pad(now.getDate())}-${half}`;
     const baseName = (merged.logFileName || 'achievo.log').replace(/[/\\]/g,'');
     const p = merged.logToFile ? path.join(logDir, `${stamp}_${baseName}`) : null;
     setLogFile(p);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -20,6 +20,10 @@ contextBridge.exposeInMainWorld('api', {
   summaryTodayDiff: () => ipcRenderer.invoke('summary:todayDiff'),
   diffToday: () => ipcRenderer.invoke('diff:today'),
 
+  // app data directory helpers
+  userDataPath: () => ipcRenderer.invoke('app:userDataPath'),
+  openUserData: () => ipcRenderer.invoke('app:openUserData'),
+
   // window controls
   windowMinimize: () => ipcRenderer.invoke('window:minimize'),
   windowToggleMaximize: () => ipcRenderer.invoke('window:toggleMaximize'),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -23,6 +23,11 @@ contextBridge.exposeInMainWorld('api', {
   // app data directory helpers
   userDataPath: () => ipcRenderer.invoke('app:userDataPath'),
   openUserData: () => ipcRenderer.invoke('app:openUserData'),
+  installRoot: () => ipcRenderer.invoke('app:installRoot'),
+  paths: () => ipcRenderer.invoke('app:paths'),
+  openInstallRoot: () => ipcRenderer.invoke('app:openInstallRoot'),
+  openLogDir: () => ipcRenderer.invoke('app:openLogDir'),
+  openDbDir: () => ipcRenderer.invoke('app:openDbDir'),
 
   // window controls
   windowMinimize: () => ipcRenderer.invoke('window:minimize'),

--- a/electron/services/config.ts
+++ b/electron/services/config.ts
@@ -18,6 +18,8 @@ export type AppConfig = {
   // Developer logging options
   logLevel?: 'debug' | 'info' | 'error';
   logNamespaces?: string[]; // e.g., ['db','score','ai']
+  logToFile?: boolean; // write JSONL logs to userData/logFileName
+  logFileName?: string; // default achievo.log
   // Local scoring normalization parameters (ECDF + cold-start + smoothing)
   localScoring?: {
     coldStartN?: number;    // number of days to treat as calibration (no ECDF)
@@ -43,6 +45,8 @@ const defaults: AppConfig = {
   dailyCapRatio: 0.35,
   logLevel: 'info',
   logNamespaces: [],
+  logToFile: false,
+  logFileName: 'achievo.log',
   localScoring: {
     coldStartN: 3,
     windowDays: 30,

--- a/electron/services/config.ts
+++ b/electron/services/config.ts
@@ -15,6 +15,9 @@ export type AppConfig = {
   dbPollSeconds?: number;
   // Daily cap ratio for base score increment (0..1), e.g., 0.35 = 35%
   dailyCapRatio?: number;
+  // Developer logging options
+  logLevel?: 'debug' | 'info' | 'error';
+  logNamespaces?: string[]; // e.g., ['db','score','ai']
   // Local scoring normalization parameters (ECDF + cold-start + smoothing)
   localScoring?: {
     coldStartN?: number;    // number of days to treat as calibration (no ECDF)
@@ -38,6 +41,8 @@ const defaults: AppConfig = {
   aiModel: 'gpt-4o-mini',
   dbPollSeconds: 10,
   dailyCapRatio: 0.35,
+  logLevel: 'info',
+  logNamespaces: [],
   localScoring: {
     coldStartN: 3,
     windowDays: 30,

--- a/electron/services/dbInstance.ts
+++ b/electron/services/dbInstance.ts
@@ -1,4 +1,0 @@
-import { DB } from './db_sqljs';
-
-// Shared singleton DB instance to avoid divergence between multiple sql.js in-memory DBs
-export const db = new DB();

--- a/electron/services/db_sqljs.ts
+++ b/electron/services/db_sqljs.ts
@@ -7,6 +7,7 @@ import { calcProgressPercentComplex } from './progressCalculator';
 import { computeBaseUpdate } from './baseScoreEngine';
 import { getConfig } from './config';
 import type { Database as SQLDatabase } from 'sql.js';
+import { getLogger } from './logger';
 
 // Default daily cap ratio relative to yesterday's base when config is missing
 const DEFAULT_DAILY_CAP_RATIO = 0.35;
@@ -39,6 +40,7 @@ export class DB {
   private db!: any;
   private filePath: string;
   private ready: Promise<void>;
+  private logger = getLogger('db');
 
   constructor() {
     this.filePath = path.join(app.getPath('userData'), 'achievo.sqljs');
@@ -339,8 +341,8 @@ export class DB {
       localScore: (typeof loc === 'number' ? loc : 0),
       cfg: { dailyCapRatio: ratio },
     });
-    try {
-      if (process.env.ACHIEVO_DEBUG === 'db') console.debug('[DB] setDayMetrics cap', {
+    if (this.logger.enabled.debug) {
+      this.logger.debug('setDayMetrics cap', {
         date,
         prevBase,
         currentBase,
@@ -356,7 +358,7 @@ export class DB {
         incApplied: res.debug?.incApplied,
         nextBase: res.nextBase,
       });
-    } catch {}
+    }
     const nextBase = res.nextBase;
     const trend = y ? Math.round(nextBase - (y.baseScore || 0)) : (res.debug?.incApplied ?? 0);
 

--- a/electron/services/db_sqljs.ts
+++ b/electron/services/db_sqljs.ts
@@ -43,7 +43,11 @@ export class DB {
   private logger = getLogger('db');
 
   constructor() {
-    this.filePath = path.join(app.getPath('userData'), 'achievo.sqljs');
+    // Resolve install root: exe directory in packaged app; project cwd in dev
+    const installRoot = app.isPackaged ? path.dirname(app.getPath('exe')) : process.cwd();
+    const dbDir = path.join(installRoot, 'db');
+    try { if (!fsSync.existsSync(dbDir)) fsSync.mkdirSync(dbDir, { recursive: true }); } catch {}
+    this.filePath = path.join(dbDir, 'achievo.sqljs');
     this.ready = this.init();
   }
 

--- a/electron/services/db_sqljs.ts
+++ b/electron/services/db_sqljs.ts
@@ -69,11 +69,21 @@ export class DB {
     const yesterday = y ? await this.getDay(y) : null;
     const prevBase = Math.max(100, yesterday?.baseScore || 100);
     const cfg = await getConfig();
-    const capRatio = Number.isFinite(cfg.dailyCapRatio as any) ? Math.max(0, Math.min(1, (cfg.dailyCapRatio as number))) : DEFAULT_DAILY_CAP_RATIO;
-    const baseCandidate = this.computeCumulativeBase(prevBase, ins, del, capRatio);
+    const ratio = Number.isFinite(cfg.dailyCapRatio as any) ? Math.max(0, Math.min(1, (cfg.dailyCapRatio as number))) : DEFAULT_DAILY_CAP_RATIO;
     const exists = await this.getDay(date);
     if (!exists) {
-      const trend = yesterday ? Math.round(baseCandidate - yesterday.baseScore) : 0;
+      // compute next base from prevBase with today's lines only, no ai/local at this point
+      const res = computeBaseUpdate({
+        prevBase,
+        currentBase: prevBase,
+        insertions: ins,
+        deletions: del,
+        aiScore: 0,
+        localScore: 0,
+        cfg: { dailyCapRatio: ratio },
+      });
+      const nextBase = res.nextBase;
+      const trend = yesterday ? Math.round(nextBase - yesterday.baseScore) : (res.debug?.incApplied ?? 0);
       // progressPercent derives from complex model using existing (null) ai/local as 0
       const hasChanges = (ins + del) > 0;
       const progressPercent = calcProgressPercentComplex({
@@ -86,7 +96,7 @@ export class DB {
         cap: 25,
       });
       this.db.run(`INSERT INTO days(date, insertions, deletions, baseScore, trend, progressPercent, summary, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [date, ins, del, baseCandidate, trend, progressPercent, null, now, now]);
+        [date, ins, del, nextBase, trend, progressPercent, null, now, now]);
     } else {
       // If today's summary has been generated (lastGenAt present), do NOT mutate baseScore here.
       // Summary becomes authoritative for today's base/trend.
@@ -106,9 +116,19 @@ export class DB {
         this.db.run(`UPDATE days SET insertions=?, deletions=?, trend=?, progressPercent=?, updatedAt=? WHERE date=?`,
           [ins, del, trend, progressPercent, now, date]);
       } else {
-        // Do not let baseScore regress due to periodic line-only recomputation
-        const safeBase = Math.max(Math.max(100, exists.baseScore || 0), baseCandidate);
-        const trend = yesterday ? Math.round(safeBase - yesterday.baseScore) : 0;
+        const currentBase = Math.max(prevBase, Math.max(100, exists.baseScore || 0));
+        const res = computeBaseUpdate({
+          prevBase,
+          currentBase,
+          insertions: ins,
+          deletions: del,
+          aiScore: Math.max(0, exists.aiScore ?? 0),
+          localScore: Math.max(0, exists.localScore ?? 0),
+          cfg: { dailyCapRatio: ratio },
+        });
+        // Do not let baseScore regress; keep at least currentBase
+        const nextBase = Math.max(currentBase, res.nextBase);
+        const trend = yesterday ? Math.round(nextBase - yesterday.baseScore) : (res.debug?.incApplied ?? 0);
         const hasChanges = (ins + del) > 0;
         const progressPercent = calcProgressPercentComplex({
           trend,
@@ -120,7 +140,7 @@ export class DB {
           cap: 25,
         });
         this.db.run(`UPDATE days SET insertions=?, deletions=?, baseScore=?, trend=?, progressPercent=?, updatedAt=? WHERE date=?`,
-          [ins, del, safeBase, trend, progressPercent, now, date]);
+          [ins, del, nextBase, trend, progressPercent, now, date]);
       }
     }
     await this.persist();
@@ -228,23 +248,7 @@ export class DB {
     await fs.writeFile(this.filePath, Buffer.from(data));
   }
 
-  private computeCumulativeBase(prevBase: number, insertions: number, deletions: number, capRatio: number): number {
-    // Daily increment with diminishing returns
-    const wAdded = 1.6;
-    const wRemoved = 0.8;
-    const raw = Math.max(0, insertions) * wAdded + Math.max(0, deletions) * wRemoved;
-    const alpha = 220;
-    const dailyInc = 100 * (1 - Math.exp(-raw / alpha)); // 0..~100 increment
-    const base0 = Math.max(100, prevBase);
-    // Cap the daily increase to capRatio of previous base
-    const ratio = Number.isFinite(capRatio) && capRatio >= 0 && capRatio <= 1 ? capRatio : DEFAULT_DAILY_CAP_RATIO;
-    const incCapped = Math.min(Math.max(0, dailyInc), base0 * ratio);
-    // 避免极小正增量被四舍五入为 0
-    const incApplied = incCapped > 0 && incCapped < 1 ? 1 : Math.round(incCapped);
-    const next = base0 + incApplied;
-    try { if (process.env.ACHIEVO_DEBUG === 'db') console.debug('[DB] computeCumulativeBase', { prevBase: base0, insertions, deletions, dailyInc: Math.round(dailyInc), cap: base0 * ratio, applied: incApplied, next }); } catch {}
-    return next;
-  }
+  // computeCumulativeBase removed; base progression is handled by baseScoreEngine.computeBaseUpdate
 
   async getDay(date: string): Promise<DayRow | null> {
     await this.ready;
@@ -272,11 +276,12 @@ export class DB {
       const yesterday = y ? await this.getDay(y) : null;
       const prevBase = Math.max(100, yesterday?.baseScore || 100);
       const cfg = await getConfig();
-      const capRatio = Number.isFinite(cfg.dailyCapRatio as any) ? Math.max(0, Math.min(1, (cfg.dailyCapRatio as number))) : DEFAULT_DAILY_CAP_RATIO;
-      const baseScore = this.computeCumulativeBase(prevBase, ins, del, capRatio);
-      const trend = yesterday ? Math.round(baseScore - yesterday.baseScore) : 0;
+      const ratio = Number.isFinite(cfg.dailyCapRatio as any) ? Math.max(0, Math.min(1, (cfg.dailyCapRatio as number))) : DEFAULT_DAILY_CAP_RATIO;
+      const res = computeBaseUpdate({ prevBase, currentBase: prevBase, insertions: ins, deletions: del, aiScore: 0, localScore: 0, cfg: { dailyCapRatio: ratio } });
+      const nextBase = res.nextBase;
+      const trend = yesterday ? Math.round(nextBase - yesterday.baseScore) : (res.debug?.incApplied ?? 0);
       this.db.run(`INSERT INTO days(date, insertions, deletions, baseScore, trend, summary, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        [date, ins, del, baseScore, trend, null, now, now]);
+        [date, ins, del, nextBase, trend, null, now, now]);
       await this.persist();
       return (await this.getDay(date))!;
     } else {
@@ -286,12 +291,13 @@ export class DB {
       const yesterday = y ? await this.getDay(y) : null;
       const prevBase = Math.max(100, yesterday?.baseScore || 100);
       const cfg = await getConfig();
-      const capRatio = Number.isFinite(cfg.dailyCapRatio as any) ? Math.max(0, Math.min(1, (cfg.dailyCapRatio as number))) : DEFAULT_DAILY_CAP_RATIO;
-      const baseCandidate = this.computeCumulativeBase(prevBase, ins, del, capRatio);
-      const safeBase = Math.max(Math.max(100, existing.baseScore || 0), baseCandidate);
-      const trend = yesterday ? Math.round(safeBase - yesterday.baseScore) : 0;
+      const ratio = Number.isFinite(cfg.dailyCapRatio as any) ? Math.max(0, Math.min(1, (cfg.dailyCapRatio as number))) : DEFAULT_DAILY_CAP_RATIO;
+      const currentBase = Math.max(prevBase, Math.max(100, existing.baseScore || 0));
+      const res = computeBaseUpdate({ prevBase, currentBase, insertions: ins, deletions: del, aiScore: Math.max(0, existing.aiScore ?? 0), localScore: Math.max(0, existing.localScore ?? 0), cfg: { dailyCapRatio: ratio } });
+      const nextBase = Math.max(currentBase, res.nextBase);
+      const trend = yesterday ? Math.round(nextBase - yesterday.baseScore) : (res.debug?.incApplied ?? 0);
       this.db.run(`UPDATE days SET insertions=?, deletions=?, baseScore=?, trend=?, updatedAt=? WHERE date=?`,
-        [ins, del, safeBase, trend, now, date]);
+        [ins, del, nextBase, trend, now, date]);
       await this.persist();
       return (await this.getDay(date))!;
     }

--- a/electron/services/logger.ts
+++ b/electron/services/logger.ts
@@ -1,0 +1,44 @@
+// Simple namespaced logger with environment-controlled levels
+// Env vars:
+// - ACHIEVO_LOG_LEVEL: 'debug' | 'info' | 'error' (default: 'info')
+// - ACHIEVO_DEBUG_NS: comma-separated namespaces to enable at debug level (e.g., 'db,score,ai,git')
+
+export type LogLevel = 'debug' | 'info' | 'error';
+
+const levelOrder: Record<LogLevel, number> = { debug: 10, info: 20, error: 30 };
+
+function getEnvLevel(): LogLevel {
+  const v = (process.env.ACHIEVO_LOG_LEVEL || '').toLowerCase();
+  if (v === 'debug' || v === 'info' || v === 'error') return v;
+  return 'info';
+}
+
+function getNsSet(): Set<string> {
+  const raw = (process.env.ACHIEVO_DEBUG_NS || '').toLowerCase();
+  const set = new Set<string>();
+  raw.split(',').map(s => s.trim()).filter(Boolean).forEach(ns => set.add(ns));
+  return set;
+}
+
+const globalLevel: LogLevel = getEnvLevel();
+const debugNs = getNsSet();
+
+export function getLogger(namespace: string) {
+  const ns = namespace.toLowerCase();
+  const isDebug = () => levelOrder[globalLevel] <= levelOrder['debug'] || debugNs.has(ns);
+  const isInfo = () => levelOrder[globalLevel] <= levelOrder['info'];
+  const isError = () => levelOrder[globalLevel] <= levelOrder['error'];
+
+  const prefix = `[${namespace}]`;
+
+  return {
+    enabled: {
+      debug: isDebug(),
+      info: isInfo(),
+      error: isError(),
+    },
+    debug: (...args: any[]) => { if (isDebug()) { try { console.debug(prefix, ...args); } catch { /* noop */ } } },
+    info: (...args: any[]) => { if (isInfo()) { try { console.info(prefix, ...args); } catch { /* noop */ } } },
+    error: (...args: any[]) => { if (isError()) { try { console.error(prefix, ...args); } catch { /* noop */ } } },
+  };
+}

--- a/electron/services/logger.ts
+++ b/electron/services/logger.ts
@@ -13,15 +13,35 @@ function getEnvLevel(): LogLevel {
   return 'info';
 }
 
-function getNsSet(): Set<string> {
+function getEnvNsSet(): Set<string> {
   const raw = (process.env.ACHIEVO_DEBUG_NS || '').toLowerCase();
   const set = new Set<string>();
   raw.split(',').map(s => s.trim()).filter(Boolean).forEach(ns => set.add(ns));
   return set;
 }
 
-const globalLevel: LogLevel = getEnvLevel();
-const debugNs = getNsSet();
+let globalLevel: LogLevel = getEnvLevel();
+let debugNs: Set<string> = getEnvNsSet();
+
+export function setLoggerLevel(level: LogLevel) {
+  globalLevel = level;
+}
+
+export function setLoggerNamespaces(namespaces: string[]) {
+  const set = new Set<string>();
+  (namespaces || []).map(s => String(s || '').toLowerCase().trim()).filter(Boolean).forEach(ns => set.add(ns));
+  debugNs = set;
+}
+
+export function applyLoggerConfig(cfg: { logLevel?: LogLevel; logNamespaces?: string[] } | undefined) {
+  if (!cfg) return;
+  if (cfg.logLevel && (cfg.logLevel === 'debug' || cfg.logLevel === 'info' || cfg.logLevel === 'error')) {
+    setLoggerLevel(cfg.logLevel);
+  }
+  if (Array.isArray(cfg.logNamespaces)) {
+    setLoggerNamespaces(cfg.logNamespaces);
+  }
+}
 
 export function getLogger(namespace: string) {
   const ns = namespace.toLowerCase();

--- a/electron/services/logger.ts
+++ b/electron/services/logger.ts
@@ -56,7 +56,9 @@ export function setLogFile(path: string | null) {
 
 function writeJsonl(ns: string, level: LogLevel, payload: any) {
   if (!filePath || !fsAsync) return;
-  const line = JSON.stringify({ ts: Date.now(), ns, level, ...payload }) + '\n';
+  const now = Date.now();
+  const ts_iso = new Date(now).toISOString();
+  const line = JSON.stringify({ ts: now, ts_iso, ns, level, ...payload }) + '\n';
   // Serialize writes to avoid interleaving
   writeQueue = writeQueue.then(() => fsAsync!.appendFile(filePath as string, line, 'utf-8')).catch(()=>{});
 }

--- a/electron/services/progressEngine.ts
+++ b/electron/services/progressEngine.ts
@@ -1,4 +1,5 @@
 import { normalizeLocalByECDF, normalizeLocalNormalCDF } from './progressCalculator';
+import { getLogger } from './logger';
 
 export type LocalScoringConfig = {
   coldStartN: number;
@@ -80,7 +81,8 @@ export function computeLocalProgress(input: ComputeLocalInput): ComputeLocalOutp
     }
   }
 
-  const debug = (process.env.ACHIEVO_DEBUG === 'score') ? {
+  const logger = getLogger('score');
+  const debug = logger.enabled.debug ? {
     samples: samples.length,
     coldStart,
     cap,
@@ -91,6 +93,9 @@ export function computeLocalProgress(input: ComputeLocalInput): ComputeLocalOutp
     alpha: Math.max(0, Math.min(1, cfg.alpha)),
     afterSmooth: localScore,
   } : undefined;
+  if (logger.enabled.debug) {
+    logger.debug('computeLocalProgress', { samples: samples.length, coldStart, cap, beforeSmooth, prevLocal: input.prevLocal, prevLocalRaw: input.prevLocalRaw ?? null, prevLocalNorm: prevNorm, alpha: Math.max(0, Math.min(1, cfg.alpha)), afterSmooth: localScore });
+  }
 
   return { localScoreRaw: input.rawLocal, localScore, debug };
 }

--- a/electron/services/summaryService.ts
+++ b/electron/services/summaryService.ts
@@ -5,7 +5,7 @@ import { Storage } from './storage';
 import { todayKey } from './dateUtil';
 import { calcProgressPercentComplex } from './progressCalculator';
 import { computeLocalProgress } from './progressEngine';
-import { makeDefaultPorts } from './ports';
+import { makeDefaultPorts, type Ports } from './ports';
 
 export type SummaryResult = {
   date: string;
@@ -24,15 +24,15 @@ export type SummaryResult = {
 
 const storage = new Storage();
 
-export async function buildTodayUnifiedDiff(): Promise<{ date: string; diff: string }> {
-  const { git } = await makeDefaultPorts();
+export async function buildTodayUnifiedDiff(deps?: Parameters<typeof makeDefaultPorts>[0]): Promise<{ date: string; diff: string }> {
+  const { git } = await makeDefaultPorts(deps);
   const today = todayKey();
   const diff = await git.getUnifiedDiffSinceDate(today);
   return { date: today, diff };
 }
 
-export async function generateTodaySummary(opts?: { onProgress?: (done: number, total: number) => void }): Promise<SummaryResult> {
-  const { db: pdb, git, cfg, summarizer } = await makeDefaultPorts();
+export async function generateTodaySummary(opts?: { onProgress?: (done: number, total: number) => void }, deps?: Parameters<typeof makeDefaultPorts>[0]): Promise<SummaryResult> {
+  const { db: pdb, git, cfg, summarizer } = await makeDefaultPorts(deps);
   const today = todayKey();
   // Local scoring parameters
   const ls = (cfg as any).localScoring || {};

--- a/electron/services/summaryService.ts
+++ b/electron/services/summaryService.ts
@@ -6,6 +6,7 @@ import { todayKey } from './dateUtil';
 import { calcProgressPercentComplex } from './progressCalculator';
 import { computeLocalProgress } from './progressEngine';
 import { makeDefaultPorts, type Ports } from './ports';
+import { getLogger } from './logger';
 
 export type SummaryResult = {
   date: string;
@@ -23,11 +24,13 @@ export type SummaryResult = {
 };
 
 const storage = new Storage();
+const logger = getLogger('summary');
 
 export async function buildTodayUnifiedDiff(deps?: Parameters<typeof makeDefaultPorts>[0]): Promise<{ date: string; diff: string }> {
   const { git } = await makeDefaultPorts(deps);
   const today = todayKey();
   const diff = await git.getUnifiedDiffSinceDate(today);
+  if (logger.enabled.debug) logger.debug('buildTodayUnifiedDiff', { today, diffLen: diff.length });
   return { date: today, diff };
 }
 
@@ -52,7 +55,7 @@ export async function generateTodaySummary(opts?: { onProgress?: (done: number, 
   const diff = await git.getUnifiedDiffSinceDate(today);
   const feats = extractDiffFeatures(diff);
   const localScoreRaw = scoreFromFeatures(feats);
-  try { if (process.env.ACHIEVO_DEBUG === 'score') console.debug('[Score] raw', { today, localScoreRaw, feats }); } catch {}
+  if (logger.enabled.debug) logger.debug('features & raw score', { today, localScoreRaw, featsSummary: { codeFiles: feats.codeFiles, testFiles: feats.testFiles, docFiles: feats.docFiles, configFiles: feats.configFiles, hunks: feats.hunks } });
   // Build history window for ECDF (last 30 days, excluding today)
   const startDate = (() => { const d = new Date(today + 'T00:00:00'); d.setDate(d.getDate() - Math.max(7, LS_WIN_D)); return d.toISOString().slice(0,10); })();
   const historyRows = await pdb.getDaysRange(startDate, today);
@@ -97,7 +100,7 @@ export async function generateTodaySummary(opts?: { onProgress?: (done: number, 
     prevLocalRaw,
   });
   let localScore = engineOut.localScore;
-  try { if (process.env.ACHIEVO_DEBUG === 'score') console.debug('[Score] engine', engineOut.debug); } catch {}
+  if (logger.enabled.debug) logger.debug('local progress engine', engineOut.debug);
 
   // Numstat for counts & context
   const ns = await git.getNumstatSinceDate(today);
@@ -146,6 +149,7 @@ export async function generateTodaySummary(opts?: { onProgress?: (done: number, 
       hasChanges,
       cap: 25,
     });
+    if (logger.enabled.debug) logger.debug('progress percent', { today, trend, prevBase, localScore, aiScore, total: ns.insertions + ns.deletions, progressPercent });
   } catch {}
 
   // Persist summary & aggregates & metrics & meta
@@ -169,6 +173,7 @@ export async function generateTodaySummary(opts?: { onProgress?: (done: number, 
       chunksCount: typeof summaryRes.chunksCount === 'number' ? summaryRes.chunksCount : undefined,
       lastGenAt,
     });
+    if (logger.enabled.info) logger.info('summary persisted', { today, aiScore, localScore, progressPercent, tokens: estTokens, durationMs: summaryRes.durationMs, chunksCount: summaryRes.chunksCount });
     const record = { timestamp: Date.now(), score: aiScore, summary: markdown || '（无内容）' };
     await storage.append(record);
     // attach meta for return

--- a/electron/services/tracker.ts
+++ b/electron/services/tracker.ts
@@ -14,9 +14,10 @@ export class TrackerService {
   private timer: NodeJS.Timeout | null = null;
   private lastProcessedCommit: string | null = null;
   private lastError: string | null = null;
-  private db = new DB();
+  private db: DB;
   private repoPath: string | undefined;
   private intervalMs = 30_000; // default 30s
+  constructor(db?: DB) { this.db = db ?? new DB(); }
 
   async start(repoPath?: string, intervalMs?: number) {
     const cfg = await getConfig();

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -22,6 +22,9 @@ const Settings: React.FC = () => {
   const [quoteLetterSpacing, setQuoteLetterSpacing] = useState<number>(0);
   const [dbPollSeconds, setDbPollSeconds] = useState<number>(10);
   const [dailyCapRatioPct, setDailyCapRatioPct] = useState<number>(35);
+  // Developer logging
+  const [logLevel, setLogLevel] = useState<'debug'|'info'|'error'>('info');
+  const [logNamespacesText, setLogNamespacesText] = useState<string>('');
   // Learning curve (local scoring) parameters
   const [lsColdStartN, setLsColdStartN] = useState<number>(3);
   const [lsWindowDays, setLsWindowDays] = useState<number>(30);
@@ -61,6 +64,10 @@ const Settings: React.FC = () => {
     if (typeof dps === 'number' && dps > 0) setDbPollSeconds(dps);
     const dcr = (cfg as any).dailyCapRatio;
     if (typeof dcr === 'number' && dcr >= 0) setDailyCapRatioPct(Math.round(dcr * 100));
+    const ll = (cfg as any).logLevel;
+    if (ll === 'debug' || ll === 'info' || ll === 'error') setLogLevel(ll);
+    const lns = Array.isArray((cfg as any).logNamespaces) ? ((cfg as any).logNamespaces as string[]) : [];
+    setLogNamespacesText(lns.join(','));
     const ls = (cfg as any).localScoring || {};
     if (typeof ls.coldStartN === 'number') setLsColdStartN(ls.coldStartN);
     if (typeof ls.windowDays === 'number') setLsWindowDays(ls.windowDays);
@@ -98,6 +105,8 @@ const Settings: React.FC = () => {
       quoteLetterSpacing,
       dbPollSeconds,
       dailyCapRatio: Math.max(0, Math.min(1, (dailyCapRatioPct || 0) / 100)),
+      logLevel,
+      logNamespaces: logNamespacesText.split(',').map(s=>s.trim()).filter(Boolean),
       localScoring: {
         coldStartN: Math.max(0, Math.floor(lsColdStartN || 0)),
         windowDays: Math.max(7, Math.floor(lsWindowDays || 30)),
@@ -118,6 +127,8 @@ const Settings: React.FC = () => {
       window.dispatchEvent(new CustomEvent('config:updated', { detail: {
         quoteFontSize, quoteEnabled, quoteRefreshSeconds, quoteLetterSpacing, dbPollSeconds,
         dailyCapRatio: Math.max(0, Math.min(1, (dailyCapRatioPct || 0) / 100)),
+        logLevel,
+        logNamespaces: logNamespacesText.split(',').map(s=>s.trim()).filter(Boolean),
         localScoring: {
           coldStartN: Math.max(0, Math.floor(lsColdStartN || 0)),
           windowDays: Math.max(7, Math.floor(lsWindowDays || 30)),
@@ -198,6 +209,38 @@ const Settings: React.FC = () => {
           </div>
         </div>
         <p className="text-xs text-slate-400 mt-2">备注：若未填 AI API Key，将回退到 OpenAI API Key，再回退到环境变量 OPENAI_API_KEY。</p>
+      </section>
+      {/* Card: 开发者选项（日志） */}
+      <section className="bg-gradient-to-b from-slate-800/80 to-slate-900/60 border border-slate-700/70 rounded-lg p-4 shadow-lg">
+        <header className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-semibold text-slate-100">开发者选项</h3>
+          <span className="text-xs text-slate-400">日志级别与命名空间</span>
+        </header>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs text-slate-400 mb-1">日志级别</label>
+            <select
+              value={logLevel}
+              onChange={e=>setLogLevel(e.target.value as any)}
+              className="w-40 bg-slate-900/60 border border-slate-700 rounded-md p-2 outline-none focus:ring-2 focus:ring-indigo-500/50"
+            >
+              <option value="debug">debug（调试）</option>
+              <option value="info">info（信息）</option>
+              <option value="error">error（错误）</option>
+            </select>
+            <p className="text-xs text-slate-500 mt-1">影响全局日志级别。</p>
+          </div>
+          <div>
+            <label className="block text-xs text-slate-400 mb-1">日志命名空间（逗号分隔）</label>
+            <input
+              value={logNamespacesText}
+              onChange={e=>setLogNamespacesText(e.target.value)}
+              className="w-full bg-slate-900/60 border border-slate-700 rounded-md p-2 outline-none focus:ring-2 focus:ring-indigo-500/50"
+              placeholder="db,score,ai,git"
+            />
+            <p className="text-xs text-slate-500 mt-1">在 info 级别下，指定的命名空间也会输出 debug 日志。</p>
+          </div>
+        </div>
       </section>
       {/* Card: 学习曲线（本地进步分） */}
       <section className="bg-gradient-to-b from-slate-800/80 to-slate-900/60 border border-slate-700/70 rounded-lg p-4 shadow-lg">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -27,7 +27,9 @@ const Settings: React.FC = () => {
   const [logNamespacesText, setLogNamespacesText] = useState<string>('');
   const [logToFile, setLogToFile] = useState<boolean>(false);
   const [logFileName, setLogFileName] = useState<string>('achievo.log');
-  const [userDataPath, setUserDataPath] = useState<string>('');
+  const [installRoot, setInstallRoot] = useState<string>('');
+  const [logDir, setLogDir] = useState<string>('');
+  const [dbDir, setDbDir] = useState<string>('');
   // Learning curve (local scoring) parameters
   const [lsColdStartN, setLsColdStartN] = useState<number>(3);
   const [lsWindowDays, setLsWindowDays] = useState<number>(30);
@@ -76,9 +78,13 @@ const Settings: React.FC = () => {
     const lfn = (cfg as any).logFileName;
     if (typeof lfn === 'string' && lfn.trim()) setLogFileName(lfn);
     try {
-      if ((window as any).api?.userDataPath) {
-        const p = await (window as any).api.userDataPath();
-        if (typeof p === 'string') setUserDataPath(p);
+      if ((window as any).api?.paths) {
+        const p = await (window as any).api.paths();
+        if (p && typeof p === 'object') {
+          setInstallRoot(p.installRoot || '');
+          setLogDir(p.logDir || '');
+          setDbDir(p.dbDir || '');
+        }
       }
     } catch {}
     const ls = (cfg as any).localScoring || {};
@@ -274,21 +280,50 @@ const Settings: React.FC = () => {
               placeholder="achievo.log"
               disabled={!logToFile}
             />
-            <p className="text-xs text-slate-500 mt-1">文件将保存在应用数据目录（userData）下。</p>
+            <p className="text-xs text-slate-500 mt-1">文件将保存在下方“日志目录”中（保存时会按时间戳生成新文件）。</p>
           </div>
           <div className="col-span-1 flex flex-col gap-2">
-            <label className="block text-xs text-slate-400 mb-1">应用数据目录</label>
+            <label className="block text-xs text-slate-400 mb-1">安装目录</label>
             <div className="flex items-center gap-2">
               <button
-                onClick={async ()=>{ try { const p = await (window as any).api.userDataPath(); setUserDataPath(p||''); } catch{} }}
+                onClick={async ()=>{ try { const p = await (window as any).api.installRoot(); setInstallRoot(p||''); } catch{} }}
                 className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100 transition-colors"
-              >显示路径</button>
+              >刷新路径</button>
               <button
-                onClick={async ()=>{ try { await (window as any).api.openUserData(); } catch{} }}
+                onClick={async ()=>{ try { await (window as any).api.openInstallRoot(); } catch{} }}
                 className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100 transition-colors"
               >打开目录</button>
             </div>
-            {userDataPath && <p className="text-xs text-slate-400 break-all mt-1">{userDataPath}</p>}
+            {installRoot && <p className="text-xs text-slate-400 break-all mt-1">{installRoot}</p>}
+          </div>
+          <div className="col-span-1 flex flex-col gap-2">
+            <label className="block text-xs text-slate-400 mb-1">日志目录</label>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={async ()=>{ try { const p = await (window as any).api.paths(); setLogDir(p?.logDir||''); } catch{} }}
+                className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100 transition-colors"
+              >刷新路径</button>
+              <button
+                onClick={async ()=>{ try { await (window as any).api.openLogDir(); } catch{} }}
+                className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100 transition-colors"
+              >打开目录</button>
+            </div>
+            {logDir && <p className="text-xs text-slate-400 break-all mt-1">{logDir}</p>}
+            <p className="text-xs text-slate-500 mt-1">当前日志文件将保存为：YYYYMMDD-HHMMSS_{logFileName}</p>
+          </div>
+          <div className="col-span-1 flex flex-col gap-2">
+            <label className="block text-xs text-slate-400 mb-1">数据库目录</label>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={async ()=>{ try { const p = await (window as any).api.paths(); setDbDir(p?.dbDir||''); } catch{} }}
+                className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100 transition-colors"
+              >刷新路径</button>
+              <button
+                onClick={async ()=>{ try { await (window as any).api.openDbDir(); } catch{} }}
+                className="px-3 py-2 rounded-md bg-slate-700 hover:bg-slate-600 border border-slate-600 text-slate-100 transition-colors"
+              >打开目录</button>
+            </div>
+            {dbDir && <p className="text-xs text-slate-400 break-all mt-1">{dbDir}\achievo.sqljs</p>}
           </div>
         </div>
       </section>


### PR DESCRIPTION
# Achievo V1.1.3 功能与变更汇总（2025-10-07）

> 本文根据今日（本地时间）的最新工作（含未推送提交）整理，概述新增功能、交互优化与缺陷修复，便于发布与回顾。

## 今日概览
- **[日期]** 2025-10-07
- **[版本]** 1.1.3
- **[范围]** 仓库页数据库导入/导出、仓库切换即时刷新、基础分/趋势一致性修复、Windows Git 长路径修复、设置文案与入口调整

## 主要特性（Features）
- **[仓库页：数据库导入/导出]**
  - 在 `Repo.tsx` 将“导出数据库”“导入数据库”与“复制路径/打开数据库目录”并列，统一通过 Toast 反馈结果。
  - `electron/main.ts` 新增 IPC：`db:export`、`db:import`（导入前自动备份 `.bak.<timestamp>.sqljs`，导入后广播 `db:imported`）。
  - `electron/preload.ts` 暴露 `dbExport()`、`dbImport()`、`onDbImportedOnce()` 给前端。
- **[仓库切换：即时清空并重载]**
  - `Dashboard.tsx` 监听 `config:updated(repoPath)`：
    - 立刻清空“今日/汇总/趋势/AI 元数据”等状态，避免跨仓数据混淆。
    - 取消防抖，立即依次拉取 `loadTodayLive()/loadToday()/loadTotals()/loadDailyRange()`。
    - `loadToday()` 直接从 DB 读取 `summary` 填充，杜绝旧仓库文案残留。
- **[设置：文案与入口优化]**
  - `SettingsDatabase.tsx` 将“数据库轮询间隔（秒）”重命名为“仪表盘刷新间隔（秒）”，新增说明文字。
  - 移除设置页的“导入/导出数据库”按钮，统一在“仓库”页操作，入口更聚合。

## 缺陷修复（Fixes）
- **[Windows Git：长路径]**
  - `gitAnalyzer.ts` 在每个仓库首次操作前自动执行 `git config core.longpaths true`（仅 Windows），修复“Filename too long”。
- **[基线提交解析：避免多行父提交导致的路径误解]**
  - `gitAnalyzer.ts:getDiffNumstat()` 改用 `rev-parse <toCommit>^` 获取第一父单一哈希，避免将多行输出拼接为路径引发错误。
- **[基础分与趋势一致性]**
  - `db_sqljs.ts:setDayCounts()`（当日已有总结 `lastGenAt`）：
    - 使用回退 `prevBase = max(100, yesterday?.baseScore || 100)`，并以 `trend = keepBase - prevBase` 计算，避免“昨日缺失→趋势=0”。
  - `db_sqljs.ts:setDayBaseScore()`：与上同一回退策略；去除对 `baseScore` 的 0..100 截断，保留实际值（四舍五入）。
  - `main.ts:stats:getToday`：若检测到 `trend !== (baseScore - prevBase)`，自动调用 `setDayBaseScore()` 纠正并返回修正后的行，确保重启/切仓后一致。

## 行为变更（Breaking/Behavior Changes）
- **[基础分不再截断到 0..100]**
  - 现在按真实基础分入库（四舍五入）。在极端情况下，趋势展示会更贴近实际计算结果。
- **[切仓刷新策略调整]**
  - 由“延迟/防抖”改为“立即刷新”。切换仓库后会瞬时清空并重新加载，UI 反馈更确定。
- **[导入/导出入口位置调整]**
  - 统一到“仓库”页，设置页不再提供该入口。

## 受影响文件
- `electron/main.ts`
- `electron/preload.ts`
- `electron/services/gitAnalyzer.ts`
- `electron/services/db_sqljs.ts`
- `src/components/Repo.tsx`
- `src/components/Dashboard.tsx`
- `src/components/settings/SettingsDatabase.tsx`

## 今日提交（自 00:00 起）
> 近期存在未推送的本地变更，此处仅列概要，具体以实际日志为准。
- feat(repo): 新增数据库导入/导出入口与 Toast 反馈，IPC 支持备份与事件广播
- chore(settings): 文案改为“仪表盘刷新间隔”，移除导入/导出按钮
- fix(git): Windows 启用 core.longpaths；父提交解析改用 rev-parse，避免多行输出
- fix(db): 修复趋势与基础分不一致；移除基础分 0..100 截断
- feat(dashboard): 切仓即时清空并重载；今日总结从 DB 直接读取
